### PR TITLE
test: JaCoCo를 통한 테스트 커버리지 측정 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# JaCoCo coverage reports
+.jacoco/
+*.exec
+
 ### STS ###
 .apt_generated
 .factorypath

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ API Base URL: `http://localhost:8080/api`
 ./gradlew build -x test
 ```
 
+### 테스트 커버리지
+
+```bash
+# 테스트 실행 및 커버리지 리포트 생성
+./gradlew test jacocoTestReport
+
+# 커버리지 검증 (최소 70% 기준)
+./gradlew jacocoTestCoverageVerification
+
+# 커버리지 리포트 확인
+open build/reports/jacoco/test/html/index.html
+```
+
+커버리지 리포트는 다음 위치에서 확인할 수 있습니다:
+- **HTML**: `build/reports/jacoco/test/html/index.html`
+- **XML**: `build/reports/jacoco/test/jacocoTestReport.xml`
+
 ### 빌드
 
 ```bash
@@ -168,6 +185,14 @@ JWT 설정은 `src/main/resources/application.yaml`에서 관리됩니다.
 - **단위 테스트**: Service 레이어 중심 (`@ExtendWith(MockitoExtension.class)`)
 - **통합 테스트**: Controller 레이어 (`@WebMvcTest`, `@WithAuthUser`)
 - **리포지토리 테스트**: `@DataJpaTest`
+
+### 테스트 커버리지 정책
+
+- **JaCoCo**를 사용한 자동 커버리지 측정
+- **최소 커버리지 목표**: 70% (전체), 60% (클래스별)
+- **제외 대상**: DTO, Entity, Configuration, Application 클래스
+- 테스트 실행 시 자동으로 커버리지 리포트 생성
+- `./gradlew check` 실행 시 커버리지 검증 자동 수행
 
 ### 알려진 개선 과제
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.6.7'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'io.zoooohs'
@@ -36,6 +37,48 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.4'
 }
 
+jacoco {
+	toolVersion = "0.8.9"
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+		csv.required = false
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			limit {
+				minimum = 0.70
+			}
+		}
+		rule {
+			element = 'CLASS'
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.60
+			}
+			excludes = [
+				'*.dto.*',
+				'*.entity.*',
+				'*.configuration.*',
+				'*.*Application'
+			]
+		}
+	}
+}
+
+check {
+	dependsOn jacocoTestCoverageVerification
 }


### PR DESCRIPTION
## 개요

JaCoCo 플러그인을 도입하여 테스트 커버리지를 자동으로 측정하고 리포트를 생성할 수 있도록 설정했습니다.

Closes #2

## 변경사항

### 1. JaCoCo 플러그인 설정 (`build.gradle`)

```gradle
plugins {
    id 'jacoco'
}

jacoco {
    toolVersion = "0.8.9"
}
```

**주요 기능**:
- ✅ 테스트 실행 시 자동으로 커버리지 리포트 생성
- ✅ HTML, XML 리포트 포맷 지원
- ✅ 커버리지 검증 자동화

### 2. 커버리지 검증 규칙

**전체 커버리지 목표**:
- 최소 70% 커버리지 달성

**클래스별 커버리지 목표**:
- 최소 60% 라인 커버리지
- 제외 대상:
  - DTO 클래스 (`*.dto.*`)
  - Entity 클래스 (`*.entity.*`)
  - Configuration 클래스 (`*.configuration.*`)
  - Application 클래스 (`*.*Application`)

### 3. 자동화 설정

- `./gradlew test` 실행 시 자동으로 `jacocoTestReport` 실행
- `./gradlew check` 실행 시 자동으로 `jacocoTestCoverageVerification` 실행
- 커버리지 미달 시 빌드 실패

### 4. 문서 업데이트

**README.md**:
- 테스트 커버리지 측정 방법 추가
- 커버리지 정책 문서화
- 리포트 확인 방법 안내

**.gitignore**:
- JaCoCo 리포트 디렉토리 무시 설정

## 사용 방법

### 테스트 및 커버리지 리포트 생성

```bash
# 테스트 실행 및 커버리지 리포트 자동 생성
./gradlew test

# 또는 명시적으로 리포트만 생성
./gradlew jacocoTestReport
```

### 커버리지 검증

```bash
# 커버리지 목표 달성 여부 검증
./gradlew jacocoTestCoverageVerification

# 또는 전체 검증 (테스트 + 커버리지)
./gradlew check
```

### 리포트 확인

```bash
# HTML 리포트 열기 (macOS)
open build/reports/jacoco/test/html/index.html

# 리포트 경로
# - HTML: build/reports/jacoco/test/html/index.html
# - XML: build/reports/jacoco/test/jacocoTestReport.xml
```

## 예상 효과

### 1. 품질 지표 확보
- 실제 테스트 커버리지를 정량적으로 측정
- 테스트되지 않은 코드 영역 파악

### 2. 리팩토링 안전망
- 코드 변경 시 테스트 커버리지 변화 추적
- 회귀 버그 조기 발견

### 3. 개발 프로세스 개선
- 새로운 코드 작성 시 테스트 작성 장려
- PR 리뷰 시 커버리지 확인 가능

### 4. CI/CD 통합 준비
- GitHub Actions와 통합하여 자동 검증 가능
- Codecov 등 외부 서비스와 연동 가능

## 다음 단계

이 PR이 머지되면 다음 작업을 진행할 수 있습니다:

1. **현재 커버리지 측정**: 실제 커버리지 수치 확인
2. **GitHub Actions CI 구축**: PR 시 자동으로 커버리지 검증
3. **커버리지 배지 추가**: README에 커버리지 상태 표시
4. **커버리지 향상**: 낮은 커버리지 영역에 테스트 추가

## 체크리스트

- [x] JaCoCo 플러그인 설정
- [x] 커버리지 검증 규칙 설정
- [x] .gitignore 업데이트
- [x] README.md 문서화
- [x] 테스트 가능 (로컬 환경에서 검증 필요)

## 참고

- [JaCoCo 공식 문서](https://www.jacoco.org/jacoco/trunk/doc/)
- [Gradle JaCoCo Plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)